### PR TITLE
feat: support typed select option overrides

### DIFF
--- a/packages/arcscord/src/base/components/interaction/component_handler.func.test-d.ts
+++ b/packages/arcscord/src/base/components/interaction/component_handler.func.test-d.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf, it } from "vitest";
 import { buildModal, modalTextInput } from "../modal";
 import { button as buttonComponent } from "../shared/builders";
-import { createButton, createModal } from "./component_handler.func";
+import { createButton, createModal, createTypedStringMenu } from "./component_handler.func";
 
 it("types ctx.params from a static route (no params)", () => {
   createButton({
@@ -78,5 +78,72 @@ it("types modal ctx.params from route", () => {
       expectTypeOf(ctx.params.type).toEqualTypeOf<string>();
       return ctx.ok();
     },
+  });
+});
+
+it("types typed string select option overrides without changing build arguments or values", () => {
+  const menu = createTypedStringMenu({
+    route: "status/{scope}",
+    values: {
+      open: { label: "Open" },
+      closed: { label: "Closed" },
+    } as const,
+    build: (id, labels: { open: string; closed: string }) => ({
+      customId: id(),
+      optionOverrides: {
+        open: {
+          label: labels.open,
+          description: "Available",
+          emoji: "✅",
+          default: true,
+        },
+        closed: {
+          label: labels.closed,
+          default: false,
+        },
+      },
+    }),
+    run: async (ctx) => {
+      expectTypeOf(ctx.values).toEqualTypeOf<("open" | "closed")[]>();
+      return ctx.ok();
+    },
+  });
+
+  expectTypeOf(menu.build).parameters.toEqualTypeOf<[{ scope: string }, { open: string; closed: string }]>();
+});
+
+it("rejects undeclared typed string select override keys", () => {
+  createTypedStringMenu({
+    route: "status",
+    values: {
+      open: { label: "Open" },
+    } as const,
+    build: id => ({
+      customId: id(),
+      optionOverrides: {
+        // @ts-expect-error Only keys declared in values can be overridden.
+        missing: { label: "Missing" },
+      },
+    }),
+    run: async ctx => ctx.ok(),
+  });
+});
+
+it("rejects value overrides for typed string select options", () => {
+  createTypedStringMenu({
+    route: "status",
+    values: {
+      open: { label: "Open" },
+    } as const,
+    build: id => ({
+      customId: id(),
+      optionOverrides: {
+        open: {
+          // @ts-expect-error Option values stay fixed and cannot be overridden.
+          value: "closed",
+        },
+      },
+    }),
+    run: async ctx => ctx.ok(),
   });
 });

--- a/packages/arcscord/src/base/components/interaction/component_handler.func.test.ts
+++ b/packages/arcscord/src/base/components/interaction/component_handler.func.test.ts
@@ -2,7 +2,7 @@ import { ComponentType } from "discord-api-types/v10";
 import { describe, expect, it } from "vitest";
 import { buildModal, modalStringSelect, modalTextInput } from "../modal";
 import { button as buttonComponent } from "../shared/builders";
-import { createButton, createModal } from "./component_handler.func";
+import { createButton, createModal, createTypedStringMenu } from "./component_handler.func";
 
 describe("component handler builders", () => {
   it("keeps static route build arguments unchanged", () => {
@@ -145,6 +145,98 @@ describe("component handler builders", () => {
       customId: "ticket/edit/$42",
       title: "Modifier",
     });
+  });
+
+  it("applies typed string select presentation overrides per build without changing values", () => {
+    const values = {
+      fun: {
+        label: "Fun",
+        description: "Static fun description",
+        emoji: "🙂",
+        default: true,
+      },
+      happy: {
+        label: "Happy",
+        description: "Static happy description",
+        emoji: "😊",
+        default: true,
+      },
+    } as const;
+    const menu = createTypedStringMenu({
+      route: "mood/{locale}",
+      values,
+      build: (id, labels: { fun: string; funDescription: string; happy: string }) => ({
+        customId: id(),
+        optionOverrides: {
+          fun: {
+            label: labels.fun,
+            description: labels.funDescription,
+            emoji: "🔥",
+            default: false,
+          },
+          happy: {
+            label: labels.happy,
+            default: false,
+          },
+        },
+      }),
+      run: async ctx => ctx.ok(ctx.values.join(",")),
+    });
+
+    expect(menu.build({ locale: "fr" }, {
+      fun: "Amusant",
+      funDescription: "Description FR",
+      happy: "Heureux",
+    })).toMatchObject({
+      components: [{
+        customId: "mood/$fr",
+        options: [
+          {
+            label: "Amusant",
+            value: "fun",
+            description: "Description FR",
+            emoji: "🔥",
+            default: false,
+          },
+          {
+            label: "Heureux",
+            value: "happy",
+            description: "Static happy description",
+            emoji: "😊",
+            default: false,
+          },
+        ],
+      }],
+    });
+
+    expect(menu.build({ locale: "en" }, {
+      fun: "Playful",
+      funDescription: "English description",
+      happy: "Cheerful",
+    })).toMatchObject({
+      components: [{
+        customId: "mood/$en",
+        options: [
+          { label: "Playful", value: "fun", description: "English description" },
+          { label: "Cheerful", value: "happy", description: "Static happy description" },
+        ],
+      }],
+    });
+    expect(values).toEqual({
+      fun: {
+        label: "Fun",
+        description: "Static fun description",
+        emoji: "🙂",
+        default: true,
+      },
+      happy: {
+        label: "Happy",
+        description: "Static happy description",
+        emoji: "😊",
+        default: true,
+      },
+    });
+    expect([...(menu.typedAllowedValues ?? [])]).toEqual(["fun", "happy"]);
   });
 
   it("supports untyped modal builders without field definitions", () => {

--- a/packages/arcscord/src/base/components/interaction/component_handler.func.ts
+++ b/packages/arcscord/src/base/components/interaction/component_handler.func.ts
@@ -19,7 +19,9 @@ import type { StringSelectMenuContext } from "#/base/components/interaction/cont
 import type { RouteVariablesObject } from "#/base/components/interaction/route";
 import type {
   ModalFields,
+  SelectOptions,
   StringSelectMenu,
+  TypedSelectMenuOptionOverrides,
   TypedSelectMenuOptions,
 } from "#/base/components/shared/component_definer.type";
 import type { PreReplyMode } from "#/utils/type/pre_reply.type";
@@ -28,6 +30,7 @@ import { createRouteId, hasComponentRouteParams } from "#/base/components/intera
 import { withModalFieldIds } from "#/base/components/modal/builders";
 import { stringSelectMenu } from "#/base/components/shared/builders";
 import { componentHandlerTypeEnum } from "#/base/components/shared/component.enum";
+import { selectMenuOptionsToAPI } from "#/base/components/shared/to_api";
 
 type HandlerOptions<T> = T extends unknown ? Omit<T, "handlerType"> : never;
 
@@ -48,7 +51,7 @@ function createRouteBuildResolver<Route extends string, Options extends unknown[
 }
 
 type TypedStringMenuOptions<
-  Options extends string[],
+  Options extends unknown[],
   Middleware extends ComponentMiddleware[],
   Route extends string,
   Values extends TypedSelectMenuOptions,
@@ -68,7 +71,10 @@ type TypedStringMenuOptions<
   build: (
     id: IdInitialiseFunction,
     ...args: Options
-  ) => Omit<StringSelectMenu<"message">, "maxValues" | "minValues" | "options" | "type">;
+  ) => Omit<StringSelectMenu<"message">, "maxValues" | "minValues" | "options" | "type"> & {
+    /** Presentation-only overrides applied to the static options for this build. */
+    optionOverrides?: TypedSelectMenuOptionOverrides<Values>;
+  };
   run: (
     ctx: StringSelectMenuContext<
       Middleware,
@@ -78,6 +84,31 @@ type TypedStringMenuOptions<
     >,
   ) => Promise<ComponentRunResult>;
 };
+
+function applyTypedSelectMenuOptionOverrides<Values extends TypedSelectMenuOptions>(
+  values: Values,
+  overrides?: TypedSelectMenuOptionOverrides<Values>,
+): TypedSelectMenuOptions | SelectOptions[] {
+  if (!overrides) {
+    return values;
+  }
+
+  const keys = Object.keys(values) as Array<keyof Values>;
+  return selectMenuOptionsToAPI(values).map((option, index) => {
+    const override = overrides[keys[index]];
+    if (!override) {
+      return option;
+    }
+
+    return {
+      ...option,
+      ...(override.label !== undefined ? { label: override.label } : {}),
+      ...(override.description !== undefined ? { description: override.description } : {}),
+      ...(override.emoji !== undefined ? { emoji: override.emoji } : {}),
+      ...(override.default !== undefined ? { default: override.default } : {}),
+    };
+  }) as SelectOptions[];
+}
 
 /**
  * Create a select menu
@@ -154,6 +185,10 @@ export function createSelectMenu<
  * > `as const`) collapses `ctx.values` back to `string` and voids the type
  * > safety this helper provides.
  *
+ * Return `optionOverrides` from `build()` to change labels, descriptions,
+ * emoji or default states per build without changing the statically declared
+ * values. Overrides are keyed by the keys of `values`.
+ *
  * @param options - The properties to configure the typed string select menu
  * @returns The complete set of properties for the typed string select menu
  * @example
@@ -171,8 +206,12 @@ export function createSelectMenu<
  *     },
  *   },
  *   maxValues: 2,
- *   build: id => ({
+ *   build: (id, labels: { fun: string; happy: string }) => ({
  *     customId: id(),
+ *     optionOverrides: {
+ *       fun: { label: labels.fun },
+ *       happy: { label: labels.happy },
+ *     },
  *   }),
  *   run: (ctx) => {
  *     const selectedValues: Array<keyof typeof typedStringSelectValues> = ctx.values;
@@ -183,7 +222,7 @@ export function createSelectMenu<
  * ```
  */
 export function createTypedStringMenu<
-  Options extends string[],
+  Options extends unknown[],
   Middleware extends ComponentMiddleware[] = ComponentMiddleware[],
   Route extends string = string,
   const Values extends TypedSelectMenuOptions = TypedSelectMenuOptions,
@@ -204,10 +243,10 @@ export function createTypedStringMenu<
     ...options,
     build: (...args: ComponentBuildArgs<Route, Options>): ActionRowData<StringSelectMenuComponentData> => {
       const [buildId, buildArgs] = resolveRouteBuild(...args);
-      const menu = options.build(buildId, ...buildArgs);
+      const { optionOverrides, ...menu } = options.build(buildId, ...buildArgs);
       return stringSelectMenu({
         ...menu,
-        options: options.values,
+        options: applyTypedSelectMenuOptionOverrides(options.values, optionOverrides),
         maxValues: options.maxValues,
         minValues: options.minValues,
       });

--- a/packages/arcscord/src/base/components/interaction/component_handlers.type.ts
+++ b/packages/arcscord/src/base/components/interaction/component_handlers.type.ts
@@ -158,7 +158,7 @@ export type ButtonComponentHandler<
  * Properties for a string select menu component.
  */
 export type StringSelectMenuComponentHandler<
-  Options extends string[] = string[],
+  Options extends unknown[] = string[],
   Middleware extends ComponentMiddleware[] = ComponentMiddleware[],
   Route extends string = string,
   Typed extends TypedSelectMenuOptions | undefined = undefined,

--- a/packages/arcscord/src/base/components/shared/component_definer.type.ts
+++ b/packages/arcscord/src/base/components/shared/component_definer.type.ts
@@ -219,6 +219,23 @@ export type TypedSelectMenuOptions = Record<
 >;
 
 /**
+ * Presentation-only overrides for an option of a typed string select menu.
+ *
+ * The option value is intentionally excluded so the keys declared in
+ * {@link TypedSelectMenuOptions} remain the source of truth for typing and
+ * runtime validation.
+ */
+export type TypedSelectMenuOptionOverride = Partial<Omit<SelectOptions, "value">>;
+
+/**
+ * Per-option presentation overrides keyed by the values declared on a typed
+ * string select menu.
+ */
+export type TypedSelectMenuOptionOverrides<Values extends TypedSelectMenuOptions> = {
+  readonly [Value in keyof Values]?: TypedSelectMenuOptionOverride;
+};
+
+/**
  * Type for a string select menu.
  */
 export type StringSelectMenu<Usage extends ComponentUsage = ComponentUsage> = BaseSelectMenu<Usage> & {

--- a/packages/arcscord/src/base/components/shared/index.ts
+++ b/packages/arcscord/src/base/components/shared/index.ts
@@ -55,6 +55,8 @@ export type {
   StringComponentType,
   StringSelectMenu,
   StringSelectMenuValues,
+  TypedSelectMenuOptionOverride,
+  TypedSelectMenuOptionOverrides,
   TypedSelectMenuOptions,
   UserSelectMenu,
 } from "./component_definer.type";

--- a/packages/arcscord/src/index.ts
+++ b/packages/arcscord/src/index.ts
@@ -280,6 +280,8 @@ export type {
   TextInput,
   TextInputStyle,
   Thumbnail,
+  TypedSelectMenuOptionOverride,
+  TypedSelectMenuOptionOverrides,
   TypedSelectMenuOptions,
   TypedTextInput,
   UserSelectMenu,

--- a/test/compat/typescript-consumer/smoke.ts
+++ b/test/compat/typescript-consumer/smoke.ts
@@ -1,3 +1,4 @@
+import type { TypedSelectMenuOptionOverride, TypedSelectMenuOptionOverrides } from "arcscord";
 import type { Attachment, GuildBasedChannel, Role, User } from "discord.js";
 import { CommandBotPermissionMiddleware } from "@arcscord/middleware";
 import {
@@ -113,15 +114,32 @@ const modal = createModal({
   },
 });
 
+const statusValues = {
+  open: { label: "Open" },
+  closed: { label: "Closed" },
+  archived: { label: "Archived" },
+} as const;
+const archivedOverride: TypedSelectMenuOptionOverride = {
+  emoji: "📦",
+  default: false,
+};
+const statusOverrides: TypedSelectMenuOptionOverrides<typeof statusValues> = {
+  archived: archivedOverride,
+};
+
 const multiSelect = createTypedStringMenu({
   route: "compat/select/{scope}",
-  values: {
-    open: { label: "Open" },
-    closed: { label: "Closed" },
-    archived: { label: "Archived" },
-  } as const,
+  values: statusValues,
   maxValues: 2,
-  build: id => ({ customId: id(), placeholder: "Choose statuses" }),
+  build: (id, labels: { open: string; closed: string }) => ({
+    customId: id(),
+    placeholder: "Choose statuses",
+    optionOverrides: {
+      ...statusOverrides,
+      open: { label: labels.open },
+      closed: { label: labels.closed },
+    },
+  }),
   run: async (ctx) => {
     expectExactType<IsExact<typeof ctx.params, { scope: string }>>(true);
     expectExactType<IsExact<typeof ctx.values, ("open" | "closed" | "archived")[]>>(true);
@@ -150,7 +168,7 @@ const singleSelect = createTypedStringMenu({
 });
 
 modal.build({ requestId: "request-1" });
-multiSelect.build({ scope: "all" });
+multiSelect.build({ scope: "all" }, { open: "Available", closed: "Resolved" });
 singleSelect.build();
 
 const client = new ArcClient("", { intents: [GatewayIntentBits.Guilds] });

--- a/website/docs/guide/components/select-menu.md
+++ b/website/docs/guide/components/select-menu.md
@@ -129,6 +129,7 @@ Or pass a plain `string` as the value — it becomes the label.
 | `customId` | `string` | Yes | Must be `id()`. |
 | `placeholder` | `string` | No | Placeholder text. |
 | `disabled` | `boolean` | No | Disabled state. |
+| `optionOverrides` | `TypedSelectMenuOptionOverrides<typeof values>` | No | Presentation overrides keyed by the static option values. |
 
 ```ts
 import { createTypedStringMenu } from "arcscord";
@@ -159,6 +160,78 @@ When `maxValues` is `1`, `ctx.values` is the single selected key (a string). Whe
 :::warning `values` must be static
 You must declare `values` as a static object literal asserted with `as const`, passed directly to `createTypedStringMenu` (not inside `build`). Its keys define both the `ctx.values` type **and** the set of values accepted at runtime — a selection outside that set (for example coming from an outdated message whose options no longer match) is rejected before `run` is called. Building `values` dynamically (or dropping `as const`) collapses `ctx.values` back to `string` and removes the type safety this helper provides.
 :::
+
+### Dynamic option presentation & i18next
+
+The keys in `values` must stay static, but their presentation can vary for each call to `build`.
+Return `optionOverrides` from `build` to replace an option's `label`, `description`, `emoji`, or
+`default` state. Overrides are merged with the static definition, so omitted properties keep their
+original values.
+
+`optionOverrides` is keyed by the keys of `values`. TypeScript rejects undeclared keys and does not
+offer a `value` property: changing presentation can therefore never change `ctx.values` typing or
+the runtime set used to validate interactions. The static object is not mutated, so the same handler
+can safely be built for several users or locales.
+
+```ts
+import { createTypedStringMenu } from "arcscord";
+
+const values = {
+  great: { label: "Great", description: "Feeling awesome", emoji: "🎉" },
+  okay: { label: "Okay", description: "Doing fine" },
+  bad: { label: "Bad", description: "Having a rough day" },
+} as const;
+
+type MoodPresentation = {
+  placeholder: string;
+  great: string;
+  greatDescription: string;
+  okay: string;
+  bad: string;
+  defaultMood: "great" | "okay" | "bad";
+};
+
+export const localizedMoodMenu = createTypedStringMenu({
+  route: "localized_mood",
+  values,
+  maxValues: 1,
+  build: (id, presentation: MoodPresentation) => ({
+    customId: id(),
+    placeholder: presentation.placeholder,
+    optionOverrides: {
+      great: {
+        label: presentation.great,
+        description: presentation.greatDescription,
+        emoji: "✨",
+        default: presentation.defaultMood === "great",
+      },
+      okay: {
+        label: presentation.okay,
+        default: presentation.defaultMood === "okay",
+      },
+      bad: {
+        label: presentation.bad,
+        default: presentation.defaultMood === "bad",
+      },
+    },
+  }),
+  run: async ctx => ctx.reply(`Mood: ${ctx.values}`),
+});
+```
+
+Resolve translations where `ctx.t` is available, then pass one object to `build`, just as with a
+typed modal:
+
+```ts
+localizedMoodMenu.build({
+  placeholder: ctx.t($ => $.mood.placeholder),
+  great: ctx.t($ => $.mood.great.label),
+  greatDescription: ctx.t($ => $.mood.great.description),
+  okay: ctx.t($ => $.mood.okay.label),
+  bad: ctx.t($ => $.mood.bad.label),
+  defaultMood: "okay",
+})
+```
 
 ## User select
 


### PR DESCRIPTION
- Add per-build presentation overrides for typed string menus
- Preserve static option values and selection typing
- Export override types and document localized usage
- Add runtime and type-level coverage

## Summary

<!-- What changed and why? -->

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] Build or CI

## Checklist

- [x] I searched existing issues and pull requests.
- [x] I updated tests or explained why tests are not needed.
- [x] I updated documentation when public behavior changed.
- [x] I removed tokens, secrets, and private data from examples, logs, and screenshots.

## Verification

<!-- List commands you ran, for example: pnpm test, pnpm typecheck, pnpm build, pnpm lint --fix=false. -->

