### PR TITLE
fix(webhooks): limit Fetch request body size

### DIFF
--- a/packages/webhooks/README.md
+++ b/packages/webhooks/README.md
@@ -84,6 +84,10 @@ connects `webhookEvents` to its `EventManager`.
 
 `handleRequest()` accepts a standard Fetch `Request`. Return its `response` immediately, and attach `completion` to the framework's background-task mechanism when one is available:
 
+For safety, `handleRequest()` accepts request bodies up to 1 MiB. Larger bodies
+are rejected with `413` before signature verification; the handler checks
+`Content-Length` first and also enforces the limit while reading streamed bodies.
+
 ```ts
 import {
   createWebhookHandler,

--- a/packages/webhooks/src/handler.ts
+++ b/packages/webhooks/src/handler.ts
@@ -26,6 +26,8 @@ const jsonHeaders = Object.freeze({
   "content-type": "application/json; charset=utf-8",
 });
 
+const maxFetchBodySize = 1024 * 1024;
+
 const knownEventTypes = new Set<string>(Object.values(WebhookEventTypes));
 
 type ParsedWebhook
@@ -43,7 +45,7 @@ function rawResponse(
 }
 
 function rejectedResult(
-  status: 400 | 401 | 405,
+  status: 400 | 401 | 405 | 413,
   message: string,
 ): WebhookHandleResult<RawWebhookResponse> {
   return {
@@ -53,6 +55,70 @@ function rejectedResult(
       reason: "rejected",
     }),
   };
+}
+
+type ReadRequestBodyResult
+  = { status: "ok"; body: ArrayBuffer }
+    | { status: "invalid" | "too-large" };
+
+async function readRequestBody(request: Request): Promise<ReadRequestBodyResult> {
+  const contentLength = request.headers.get("content-length");
+  if (
+    contentLength !== null
+    && /^\d+$/.test(contentLength)
+    && Number(contentLength) > maxFetchBodySize
+  ) {
+    return { status: "too-large" };
+  }
+
+  if (!request.body) {
+    return { status: "ok", body: new ArrayBuffer(0) };
+  }
+
+  let reader: ReadableStreamDefaultReader<Uint8Array>;
+  try {
+    reader = request.body.getReader();
+  }
+  catch {
+    return { status: "invalid" };
+  }
+
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        const body = new Uint8Array(size);
+        let offset = 0;
+        for (const chunk of chunks) {
+          body.set(chunk, offset);
+          offset += chunk.byteLength;
+        }
+        return { status: "ok", body: body.buffer };
+      }
+
+      if (value.byteLength > maxFetchBodySize - size) {
+        try {
+          await reader.cancel();
+        }
+        catch {
+          // The request is already rejected even if stream cancellation fails.
+        }
+        return { status: "too-large" };
+      }
+
+      chunks.push(value);
+      size += value.byteLength;
+    }
+  }
+  catch {
+    return { status: "invalid" };
+  }
+  finally {
+    reader.releaseLock();
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -292,12 +358,11 @@ export function createWebhookHandler(
       };
     }
 
-    let body: ArrayBuffer;
-    try {
-      body = await request.arrayBuffer();
-    }
-    catch {
-      const result = rejectedResult(400, "invalid request body");
+    const requestBody = await readRequestBody(request);
+    if (requestBody.status !== "ok") {
+      const result = requestBody.status === "too-large"
+        ? rejectedResult(413, "request body too large")
+        : rejectedResult(400, "invalid request body");
       return {
         response: fetchResponse(result.response),
         completion: result.completion,
@@ -305,7 +370,7 @@ export function createWebhookHandler(
     }
 
     const result = await handleRaw({
-      body,
+      body: requestBody.body,
       signature,
       timestamp,
     });

--- a/packages/webhooks/src/types.ts
+++ b/packages/webhooks/src/types.ts
@@ -202,7 +202,7 @@ export type RawWebhookRequest = {
 
 /** Serializable HTTP response returned by {@link WebhookHandler.handleRaw}. */
 export type RawWebhookResponse = {
-  status: 204 | 400 | 401 | 405;
+  status: 204 | 400 | 401 | 405 | 413;
   headers: Readonly<Record<string, string>>;
   body: string | null;
 };
@@ -267,7 +267,7 @@ export type ConfiguredWebhookSignatureOptions = Omit<
 /** Framework-neutral Discord Webhook Events request handler. */
 export type WebhookHandler = {
   /**
-   * Handles a Fetch API request and returns a Fetch response plus dispatch completion.
+   * Handles a Fetch API request up to 1 MiB and returns a Fetch response plus dispatch completion.
    */
   handleRequest: (
     request: Request,

--- a/packages/webhooks/src/webhooks.test.ts
+++ b/packages/webhooks/src/webhooks.test.ts
@@ -11,6 +11,7 @@ import {
 import { verifyWebhookSignature } from "./verification";
 
 const timestamp = "2026-07-26T12:00:00.000000+00:00";
+const maxFetchBodySize = 1024 * 1024;
 
 let publicKey = "";
 let privateKey: CryptoKey;
@@ -257,6 +258,70 @@ describe("request handling", () => {
     expect(get.response.status).toBe(405);
     expect(get.response.headers.get("allow")).toBe("POST");
     expect(unsigned.response.status).toBe(401);
+  });
+
+  it("rejects an oversized Content-Length before consuming the Fetch body", async () => {
+    const handler = createWebhookHandler({ publicKey, handlers: {} });
+    const request = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "content-length": String(maxFetchBodySize + 1),
+        "x-signature-ed25519": "00",
+        "x-signature-timestamp": timestamp,
+      },
+      body: new ReadableStream(),
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    const result = await handler.handleRequest(request);
+
+    expect(result.response.status).toBe(413);
+    expect(request.bodyUsed).toBe(false);
+  });
+
+  it("stops reading a chunked Fetch body when it exceeds the size limit", async () => {
+    const handler = createWebhookHandler({ publicKey, handlers: {} });
+    const chunk = new Uint8Array(maxFetchBodySize / 2 + 1);
+    const cancel = vi.fn();
+    const request = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "x-signature-ed25519": "00",
+        "x-signature-timestamp": timestamp,
+      },
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(chunk);
+          controller.enqueue(chunk);
+          controller.enqueue(chunk);
+        },
+        cancel,
+      }),
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    const result = await handler.handleRequest(request);
+
+    expect(result.response.status).toBe(413);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("returns 400 when the Fetch body cannot be read", async () => {
+    const handler = createWebhookHandler({ publicKey, handlers: {} });
+    const request = new Request("https://example.com", {
+      method: "POST",
+      headers: {
+        "x-signature-ed25519": "00",
+        "x-signature-timestamp": timestamp,
+      },
+      body: "{}",
+    });
+    const reader = request.body!.getReader();
+
+    const result = await handler.handleRequest(request);
+    reader.releaseLock();
+
+    expect(result.response.status).toBe(400);
   });
 });
 

--- a/website/docs/packages/webhooks.md
+++ b/website/docs/packages/webhooks.md
@@ -157,6 +157,10 @@ Payload properties stay in Discord's native `snake_case` form. The complete oute
 
 Use `handleRequest()` in frameworks based on the Fetch API, including Next.js route handlers, Hono, and Bun:
 
+`handleRequest()` limits request bodies to 1 MiB. It rejects larger bodies with
+`413` before signature verification, using `Content-Length` when available and
+enforcing the same limit while reading streamed bodies.
+
 ```ts title="app/api/discord-webhooks/route.ts"
 import type { WebhookDispatchResult } from "@arcscord/webhooks";
 import { webhooks } from "./webhooks";


### PR DESCRIPTION
- Reject bodies larger than 1 MiB with HTTP 413
- Enforce limits for both declared and streamed bodies
- Add coverage and document the request size constraint

fergot to push my bad

